### PR TITLE
Fixed parameters link

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,7 @@
 * ### Projects {docsify-ignore}
   On the PhotosynQ platform measurements are collected for a Project, including measurement Projects and Questions. Learn how to [set up a Project](tutorials/creating-a-project).
 * ### Parameters & References {docsify-ignore}
-  The MultispeQ is capable to measure a large variety of parameters. Find a list of the most common ones [here](/view-and-analyze-data/how-to-cite).
+  The MultispeQ is capable to measure a large variety of parameters. Find a list of the most common ones [here](/instruments/what-does-the-multispeq-measure).
 
 ***
 


### PR DESCRIPTION
Fixed link for 'Parameters & References' - now directs to common parameters instead of how to cite.